### PR TITLE
Handling `bundle exec`

### DIFF
--- a/lib/elastic_whenever/schedule.rb
+++ b/lib/elastic_whenever/schedule.rb
@@ -5,6 +5,7 @@ module ElasticWhenever
     attr_reader :task_definition
     attr_reader :container
     attr_reader :chronic_options
+    attr_reader :bundle_command
 
     class InvalidScheduleException < StandardError; end
 
@@ -15,6 +16,7 @@ module ElasticWhenever
       @task_definition = nil
       @container = nil
       @chronic_options = {}
+      @bundle_command = "bundle exec"
       instance_eval(File.read(file), file)
     end
 
@@ -23,7 +25,7 @@ module ElasticWhenever
     end
 
     def every(frequency, options = {}, &block)
-      @tasks << Task.new(@environment, frequency, options).tap do |task|
+      @tasks << Task.new(@environment, @bundle_command, frequency, options).tap do |task|
         task.instance_eval(&block)
       end
     end

--- a/lib/elastic_whenever/task.rb
+++ b/lib/elastic_whenever/task.rb
@@ -4,8 +4,9 @@ module ElasticWhenever
     attr_reader :frequency
     attr_reader :options
 
-    def initialize(environment, frequency, options = {})
+    def initialize(environment, bundle_command, frequency, options = {})
       @environment = environment
+      @bundle_command = bundle_command.split(" ")
       @frequency = frequency
       @options = options
       @commands = []
@@ -16,33 +17,15 @@ module ElasticWhenever
     end
 
     def rake(task)
-      @commands << [
-        "bundle",
-        "exec",
-        "rake",
-        task,
-        "--silent"
-      ]
+      @commands << [@bundle_command, "rake", task, "--silent"].flatten
     end
 
     def runner(src)
-      @commands << [
-        "bundle",
-        "exec",
-        "bin/rails",
-        "runner",
-        "-e",
-        @environment,
-        src
-      ]
+      @commands << [@bundle_command, "bin/rails", "runner", "-e", @environment, src].flatten
     end
 
     def script(script)
-      @commands << [
-        "bundle",
-        "exec",
-        "script/#{script}"
-      ]
+      @commands << [@bundle_command, "script/#{script}"].flatten
     end
 
     def method_missing(name, *args)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe ElasticWhenever::CLI do
   describe "run" do
     let(:task) do
-      ElasticWhenever::Task.new("production", "0 0 * * ? *").tap do |task|
+      ElasticWhenever::Task.new("production", "bundle exec", "0 0 * * ? *").tap do |task|
         task.runner("Hoge.run")
       end
     end

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe ElasticWhenever::Task do
-  let(:task) { ElasticWhenever::Task.new("production", :day, at: "05:00pm") }
+  let(:task) { ElasticWhenever::Task.new("production", "bundle exec", :day, at: "05:00pm") }
 
   describe "#initialize" do
     it "has attributes" do
@@ -21,6 +21,15 @@ RSpec.describe ElasticWhenever::Task do
       task.rake("hoge:run")
       expect(task.commands).to eq([%w(bundle exec rake hoge:run --silent)])
     end
+
+    context "when unset bundle command" do
+      let(:task) { ElasticWhenever::Task.new("production", "", :day, at: "05:00pm") }
+
+      it "generates rake commands" do
+        task.rake("hoge:run")
+        expect(task.commands).to eq([%w(rake hoge:run --silent)])
+      end
+    end
   end
 
   describe "#runner" do
@@ -28,12 +37,30 @@ RSpec.describe ElasticWhenever::Task do
       task.runner("Hoge.run")
       expect(task.commands).to eq([%w(bundle exec bin/rails runner -e production Hoge.run)])
     end
+
+    context "when unset bundle command" do
+      let(:task) { ElasticWhenever::Task.new("production", "", :day, at: "05:00pm") }
+
+      it "generates rake commands" do
+        task.runner("Hoge.run")
+        expect(task.commands).to eq([%w(bin/rails runner -e production Hoge.run)])
+      end
+    end
   end
 
   describe "script" do
     it "generates script commands" do
       task.script("runner.rb")
       expect(task.commands).to eq([%w(bundle exec script/runner.rb)])
+    end
+
+    context "when unset bundle command" do
+      let(:task) { ElasticWhenever::Task.new("production", "", :day, at: "05:00pm") }
+
+      it "generates rake commands" do
+        task.script("runner.rb")
+        expect(task.commands).to eq([%w(script/runner.rb)])
+      end
     end
   end
 

--- a/spec/tasks/rule_spec.rb
+++ b/spec/tasks/rule_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
 
   describe "convert" do
     it "converts scheduled task syntax" do
-      task = ElasticWhenever::Task.new("production", "0 0 * * ? *")
+      task = ElasticWhenever::Task.new("production", "bundle exec", "0 0 * * ? *")
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -29,7 +29,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts cron syntax" do
-      task = ElasticWhenever::Task.new("production", "0 0 * * *")
+      task = ElasticWhenever::Task.new("production", "bundle exec", "0 0 * * *")
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -39,7 +39,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts specified week cron syntax" do
-      task = ElasticWhenever::Task.new("production", "0 0 * * 0")
+      task = ElasticWhenever::Task.new("production", "bundle exec", "0 0 * * 0")
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -49,7 +49,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `day` shorthand with `at` option" do
-      task = ElasticWhenever::Task.new("production", :day, at: "2:00")
+      task = ElasticWhenever::Task.new("production", "bundle exec", :day, at: "2:00")
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -59,7 +59,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `day` shorthand with `at` option and chronic options" do
-      task = ElasticWhenever::Task.new("production", :day, at: "2:00")
+      task = ElasticWhenever::Task.new("production", "bundle exec", :day, at: "2:00")
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {:hours24 => true})).to have_attributes(
@@ -69,7 +69,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `hour` shorthand" do
-      task = ElasticWhenever::Task.new("production", :hour)
+      task = ElasticWhenever::Task.new("production", "bundle exec", :hour)
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -79,7 +79,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `month` shorthand" do
-      task = ElasticWhenever::Task.new("production", :month, at: "3rd")
+      task = ElasticWhenever::Task.new("production", "bundle exec", :month, at: "3rd")
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -89,7 +89,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `year` shorthand" do
-      task = ElasticWhenever::Task.new("production", :year)
+      task = ElasticWhenever::Task.new("production", "bundle exec", :year)
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -99,7 +99,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `sunday` shorthand" do
-      task = ElasticWhenever::Task.new("production", :sunday)
+      task = ElasticWhenever::Task.new("production", "bundle exec", :sunday)
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -109,7 +109,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `monday` shorthand" do
-      task = ElasticWhenever::Task.new("production", :monday, at: "10:00")
+      task = ElasticWhenever::Task.new("production", "bundle exec", :monday, at: "10:00")
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -119,7 +119,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `tuesday` shorthand" do
-      task = ElasticWhenever::Task.new("production", :tuesday)
+      task = ElasticWhenever::Task.new("production", "bundle exec", :tuesday)
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -129,7 +129,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `wednesday` shorthand" do
-      task = ElasticWhenever::Task.new("production", :wednesday)
+      task = ElasticWhenever::Task.new("production", "bundle exec", :wednesday)
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -139,7 +139,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `thursday` shorthand" do
-      task = ElasticWhenever::Task.new("production", :thursday)
+      task = ElasticWhenever::Task.new("production", "bundle exec", :thursday)
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -149,7 +149,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `friday` shorthand" do
-      task = ElasticWhenever::Task.new("production", :friday)
+      task = ElasticWhenever::Task.new("production", "bundle exec", :friday)
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -159,7 +159,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `saturday` shorthand" do
-      task = ElasticWhenever::Task.new("production", :saturday)
+      task = ElasticWhenever::Task.new("production", "bundle exec", :saturday)
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -169,7 +169,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `weekday` shorthand" do
-      task = ElasticWhenever::Task.new("production", :weekday)
+      task = ElasticWhenever::Task.new("production", "bundle exec", :weekday)
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -179,7 +179,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     end
 
     it "converts `weekend` shorthand" do
-      task = ElasticWhenever::Task.new("production", :weekend, at: "06:30")
+      task = ElasticWhenever::Task.new("production", "bundle exec", :weekend, at: "06:30")
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task, {})).to have_attributes(
@@ -190,7 +190,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
 
 
     it "raise an exception when specify unsupported option" do
-      task = ElasticWhenever::Task.new("production", :reboot)
+      task = ElasticWhenever::Task.new("production", "bundle exec", :reboot)
       task.rake "hoge:run"
 
       expect { ElasticWhenever::Task::Rule.convert(option, task, {}) }.to raise_error(ElasticWhenever::Task::Rule::UnsupportedOptionException)


### PR DESCRIPTION
Fixes #15 

Whenever handles `bundle exec` prefix with the presence or absence of `Gemfile`. However, elastic whenever cannot know whether `Gemfile` exists or not. So add `bundle exec` by default, Make it unspecified with `bundle_command` option.

```ruby
set :bundle_command, ""
```