### PR TITLE
Fix bug for setting environments via CLI

### DIFF
--- a/lib/elastic_whenever/cli.rb
+++ b/lib/elastic_whenever/cli.rb
@@ -45,10 +45,7 @@ module ElasticWhenever
       private
 
       def update_tasks(option, dry_run:)
-        schedule = Schedule.new(option.schedule_file)
-        option.variables.each do |var|
-          schedule.set(var[:key], var[:value])
-        end
+        schedule = Schedule.new(option.schedule_file, option.variables)
         schedule.validate!
 
         cluster = Task::Cluster.new(option, schedule.cluster)

--- a/lib/elastic_whenever/schedule.rb
+++ b/lib/elastic_whenever/schedule.rb
@@ -9,14 +9,16 @@ module ElasticWhenever
 
     class InvalidScheduleException < StandardError; end
 
-    def initialize(file, environment: "production")
-      @environment = environment
+    def initialize(file, variables)
+      @environment = "production"
       @tasks = []
       @cluster = nil
       @task_definition = nil
       @container = nil
       @chronic_options = {}
       @bundle_command = "bundle exec"
+
+      variables.each { |var| set(var[:key], var[:value]) }
       instance_eval(File.read(file), file)
     end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ElasticWhenever::CLI do
     let(:definition) { double(arn: "arn:aws:ecs:us-east-1:123456789:task-definition/wordpress:2", name: "wordpress:2") }
     let(:role) { double(arn: "arn:aws:ecs:us-east-1:123456789:role/testRole") }
     before do
-      allow(ElasticWhenever::Schedule).to receive(:new).with((Pathname(__dir__) + "fixtures/schedule.rb").to_s).and_return(schedule)
+      allow(ElasticWhenever::Schedule).to receive(:new).with((Pathname(__dir__) + "fixtures/schedule.rb").to_s, kind_of(Array)).and_return(schedule)
       allow(ElasticWhenever::Task::Cluster).to receive(:new).with(kind_of(ElasticWhenever::Option), "test").and_return(cluster)
       allow(ElasticWhenever::Task::Definition).to receive(:new).with(kind_of(ElasticWhenever::Option), "wordpress:2").and_return(definition)
       allow(ElasticWhenever::Task::Role).to receive(:new).with(kind_of(ElasticWhenever::Option)).and_return(role)
@@ -76,9 +76,8 @@ RSpec.describe ElasticWhenever::CLI do
         expect(ElasticWhenever::CLI.run(%W(-i test --region us-east-1 -f #{(Pathname(__dir__) + "fixtures/schedule.rb").to_s}))).to eq ElasticWhenever::CLI::SUCCESS_EXIT_CODE
       end
 
-      it "sets variables with option" do
-        expect(schedule).to receive(:set).with("environment", "staging")
-        expect(schedule).to receive(:set).with("cluster", "ecs-test")
+      it "receives schedule file name and variables" do
+        expect(ElasticWhenever::Schedule).to receive(:new).with((Pathname(__dir__) + "fixtures/schedule.rb").to_s, [{ key: "environment", value: "staging" }, { key: "cluster", value: "ecs-test" }])
 
         ElasticWhenever::CLI.run(%W(-i test --set environment=staging&cluster=ecs-test --region us-east-1 -f #{(Pathname(__dir__) + "fixtures/schedule.rb").to_s}))
       end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe ElasticWhenever::Schedule do
-  let(:schedule) { ElasticWhenever::Schedule.new((Pathname(__dir__) + "fixtures/schedule.rb").to_s) }
+  let(:schedule) { ElasticWhenever::Schedule.new((Pathname(__dir__) + "fixtures/schedule.rb").to_s, []) }
 
   describe "#initialize" do
     it "has attributes" do
@@ -11,6 +11,14 @@ RSpec.describe ElasticWhenever::Schedule do
                             container: "cron",
                             chronic_options: {},
                           )
+    end
+
+    context "when received variables from cli" do
+      let(:schedule) { ElasticWhenever::Schedule.new((Pathname(__dir__) + "fixtures/schedule.rb").to_s, [{ key: "environment", value: "staging" }]) }
+
+      it "overrides attributes" do
+        expect(schedule.instance_variable_get(:@environment)).to eq "staging"
+      end
     end
 
     it "has tasks" do
@@ -33,7 +41,7 @@ RSpec.describe ElasticWhenever::Schedule do
     end
 
     context "when use unsupported method" do
-      let(:schedule) { ElasticWhenever::Schedule.new((Pathname(__dir__) + "fixtures/unsupported_schedule.rb").to_s) }
+      let(:schedule) { ElasticWhenever::Schedule.new((Pathname(__dir__) + "fixtures/unsupported_schedule.rb").to_s, []) }
 
       it "does not have tasks" do
         expect(schedule.tasks.count).to eq(0)


### PR DESCRIPTION
The `environment` is used to build the command but doesn't refer to the value set later...