### PR TITLE
Set default time for Chronic

### DIFF
--- a/lib/elastic_whenever/schedule.rb
+++ b/lib/elastic_whenever/schedule.rb
@@ -82,7 +82,8 @@ module ElasticWhenever
     end
 
     def schedule_expression(frequency, options)
-      time = Chronic.parse(options[:at], @chronic_options) || Time.new(2017, 12, 1, 0, 0, 0)
+      opts =  { :now => Time.new(2017, 12, 1, 0, 0, 0) }.merge(@chronic_options)
+      time = Chronic.parse(options[:at], opts) || Time.new(2017, 12, 1, 0, 0, 0)
 
       case frequency
       when 1.minute

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -220,6 +220,20 @@ RSpec.describe ElasticWhenever::Schedule do
       end
     end
 
+    context "when use 2.months with `at` option" do
+      let(:file) do
+        <<~FILE
+          every 2.months, :at => "3:00" do
+            rake "hoge:run"
+          end
+        FILE
+      end
+
+      it "has expression" do
+        expect(schedule.tasks.first).to have_attributes(expression: "cron(0 15 1 1,3,5,7,9,11 ? *)")
+      end
+    end
+
     context "when use 7.months" do
       let(:file) do
         <<~FILE


### PR DESCRIPTION
By default, since the execution timing is the default, December 1 is set as the default.