### PR TITLE
CI against Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ sudo: false
 language: ruby
 rvm:
   - 2.4.2
-before_install: gem install bundler -v 1.15.4
+  - 2.5.0
+before_install:
+  - gem update --system


### PR DESCRIPTION
Hi! We develop [SideCI](https://sideci.com), and we use the gem. Thank you!
We want to update using Ruby version to 2.5.0 that is in our application.
So, I'd like to add a CI matrix that is for Ruby 2.5 to the gem.