### PR TITLE
Use `File.exist?` instead of `File.exists?`

### DIFF
--- a/lib/elastic_whenever/option.rb
+++ b/lib/elastic_whenever/option.rb
@@ -79,7 +79,7 @@ module ElasticWhenever
     end
 
     def validate!
-      raise InvalidOptionException.new("Can't find file: #{schedule_file}") unless File.exists?(schedule_file)
+      raise InvalidOptionException.new("Can't find file: #{schedule_file}") unless File.exist?(schedule_file)
     end
 
     private


### PR DESCRIPTION
Because `File.exists?` is deprecated.

```bash
$ ruby -e File.exists?("a")
-e:1: warning: File.exists? is a deprecated name, use File.exist? instead
```