### PR TITLE
add `attr_reader :enviroment`

### DIFF
--- a/lib/elastic_whenever/schedule.rb
+++ b/lib/elastic_whenever/schedule.rb
@@ -6,6 +6,7 @@ module ElasticWhenever
     attr_reader :container
     attr_reader :chronic_options
     attr_reader :bundle_command
+    attr_reader :environment
 
     class InvalidScheduleException < StandardError; end
     class UnsupportedFrequencyException < StandardError; end


### PR DESCRIPTION
Our `schdule.rb` is like  a below that works with `whenever` gem.
```ruby
if environment ==  'qa'
  every 30.minutes do
    rake 'task_qa'
  end
else 
  every 30.minutes do
    rake 'task_production'
  end
end
```
But when I tried to use elastic_whenever, it said `[warn] Skipping unsupported method: environment`.
This pull request make it work.
