### PR TITLE
fix: `Task::Role#exists?` always return true.

### DIFF
--- a/lib/elastic_whenever/task/role.rb
+++ b/lib/elastic_whenever/task/role.rb
@@ -20,7 +20,9 @@ module ElasticWhenever
       end
 
       def exists?
-        !!role
+        !!arn
+      rescue Aws::IAM::Errors::NoSuchEntity
+        false
       end
 
       def arn

--- a/spec/tasks/role_spec.rb
+++ b/spec/tasks/role_spec.rb
@@ -48,15 +48,6 @@ RSpec.describe ElasticWhenever::Task::Role do
 
     context "when role not found" do
       before do
-        allow(resource).to receive(:role).with(ElasticWhenever::Task::Role::NAME).and_return(nil)
-      end
-
-      it "returns false" do
-        expect(ElasticWhenever::Task::Role.new(option)).not_to be_exists
-      end
-    end
-    context "when role not found (deloay load)" do
-      before do
         allow(role).to receive(:arn).and_raise(Aws::IAM::Errors::NoSuchEntity.new('context','error'))
       end
 

--- a/spec/tasks/role_spec.rb
+++ b/spec/tasks/role_spec.rb
@@ -55,5 +55,14 @@ RSpec.describe ElasticWhenever::Task::Role do
         expect(ElasticWhenever::Task::Role.new(option)).not_to be_exists
       end
     end
+    context "when role not found (deloay load)" do
+      before do
+        allow(role).to receive(:arn).and_raise(Aws::IAM::Errors::NoSuchEntity.new('context','error'))
+      end
+
+      it "returns false" do
+        expect(ElasticWhenever::Task::Role.new(option)).not_to be_exists
+      end
+    end
   end
 end


### PR DESCRIPTION
I got  a error of `Aws::IAM::Errors::NoSuchEntity: Role not found for ecsEventsRole` during creating the scheduled tasks. 
It looks like `Task::Role#exists?` always return `true`. Because  `Aws::IAM::Resource#role` always return `AWS::IAM::Role` object.
