### PR TITLE
update elastic_whenever for FARGATE launch type

### DIFF
--- a/lib/elastic_whenever/cli.rb
+++ b/lib/elastic_whenever/cli.rb
@@ -46,7 +46,7 @@ module ElasticWhenever
       private
 
       def update_tasks(option, dry_run:)
-        schedule = Schedule.new(option.schedule_file, option.variables)
+        schedule = Schedule.new(option.schedule_file, option.verbose, option.variables)
         schedule.validate!
 
         cluster = Task::Cluster.new(option, schedule.cluster)

--- a/lib/elastic_whenever/option.rb
+++ b/lib/elastic_whenever/option.rb
@@ -9,6 +9,10 @@ module ElasticWhenever
     attr_reader :identifier
     attr_reader :mode
     attr_reader :variables
+    attr_reader :assign_public_ip
+    attr_reader :launch_type
+    attr_reader :security_groups
+    attr_reader :subnets
     attr_reader :schedule_file
 
     class InvalidOptionException < StandardError; end
@@ -17,6 +21,10 @@ module ElasticWhenever
       @identifier = nil
       @mode = DRYRUN_MODE
       @variables = []
+      @assign_public_ip = 'DISABLED'
+      @launch_type = 'EC2'
+      @security_groups = nil
+      @subnets = nil
       @schedule_file = 'config/schedule.rb'
       @profile = nil
       @access_key = nil
@@ -46,6 +54,18 @@ module ElasticWhenever
             key, value = pair.split('=')
             @variables << { key: key, value: value }
           end
+        end
+        opts.on('--assign_public_ip', 'Assign a public IP.') do
+          @assign_public_ip = 'ENABLED'
+        end
+        opts.on('--launch_type launch_type', 'Launch type. Defualt: EC2') do |launch_type|
+          @launch_type = launch_type
+        end
+        opts.on('--security_groups groups', "Example: --security_groups 'sg-2c503655,sg-72f0cb0a'") do |groups|
+          @security_groups = groups
+        end
+        opts.on('--subnets subnets', "Example: --subnets 'subnet-4973d63f,subnet-45827d1d'") do |subnets|
+          @subnets = subnets
         end
         opts.on('-f', '--file schedule_file', 'Default: config/schedule.rb') do |file|
           @schedule_file = file

--- a/lib/elastic_whenever/option.rb
+++ b/lib/elastic_whenever/option.rb
@@ -8,9 +8,11 @@ module ElasticWhenever
 
     attr_reader :identifier
     attr_reader :mode
+    attr_reader :verbose
     attr_reader :variables
     attr_reader :assign_public_ip
     attr_reader :launch_type
+    attr_reader :platform_version
     attr_reader :security_groups
     attr_reader :subnets
     attr_reader :schedule_file
@@ -20,9 +22,11 @@ module ElasticWhenever
     def initialize(args)
       @identifier = nil
       @mode = DRYRUN_MODE
+      @verbose = false
       @variables = []
       @assign_public_ip = 'DISABLED'
       @launch_type = 'EC2'
+      @platform_version = 'LATEST'
       @security_groups = nil
       @subnets = nil
       @schedule_file = 'config/schedule.rb'
@@ -67,6 +71,9 @@ module ElasticWhenever
         opts.on('--subnets subnets', "Example: --subnets 'subnet-4973d63f,subnet-45827d1d'") do |subnets|
           @subnets = subnets
         end
+        opts.on('--platform_version version', "For Fargate launch type, optionally specify the platform version. Example: --platform_version 1.2.0") do |version|
+          @platform_version = version
+        end
         opts.on('-f', '--file schedule_file', 'Default: config/schedule.rb') do |file|
           @schedule_file = file
         end
@@ -84,6 +91,9 @@ module ElasticWhenever
         end
         opts.on('-v', '--version', 'Print version') do
           @mode = PRINT_VERSION_MODE
+        end
+        opts.on('-V', '--verbose', 'Run rake jobs without --silent') do
+          @verbose = true
         end
       end.parse(args)
 

--- a/lib/elastic_whenever/schedule.rb
+++ b/lib/elastic_whenever/schedule.rb
@@ -51,8 +51,9 @@ module ElasticWhenever
     end
     using WheneverNumeric
 
-    def initialize(file, variables)
+    def initialize(file, verbose, variables)
       @environment = "production"
+      @verbose = verbose
       @tasks = []
       @cluster = nil
       @task_definition = nil
@@ -69,7 +70,7 @@ module ElasticWhenever
     end
 
     def every(frequency, options = {}, &block)
-      @tasks << Task.new(@environment, @bundle_command, schedule_expression(frequency, options)).tap do |task|
+      @tasks << Task.new(@environment, @verbose, @bundle_command, schedule_expression(frequency, options)).tap do |task|
         task.instance_eval(&block)
       end
     rescue UnsupportedFrequencyException => exn

--- a/lib/elastic_whenever/task.rb
+++ b/lib/elastic_whenever/task.rb
@@ -3,8 +3,9 @@ module ElasticWhenever
     attr_reader :commands
     attr_reader :expression
 
-    def initialize(environment, bundle_command, expression)
+    def initialize(environment, verbose, bundle_command, expression)
       @environment = environment
+      @verbose_mode = verbose ? '' : "--silent"
       @bundle_command = bundle_command.split(" ")
       @expression = expression
       @commands = []
@@ -15,7 +16,7 @@ module ElasticWhenever
     end
 
     def rake(task)
-      @commands << [@bundle_command, "rake", task, "--silent"].flatten
+      @commands << [@bundle_command, "rake", task, @verbose_mode].flatten
     end
 
     def runner(src)

--- a/lib/elastic_whenever/task/target.rb
+++ b/lib/elastic_whenever/task/target.rb
@@ -83,7 +83,6 @@ module ElasticWhenever
                 input: input_json(container, commands),
                 role_arn: role.arn,
                 ecs_parameters: {
-                  launch_type: launch_type,
                   task_definition_arn: definition.arn,
                   task_count: 1,
                 }

--- a/lib/elastic_whenever/task/target.rb
+++ b/lib/elastic_whenever/task/target.rb
@@ -7,6 +7,7 @@ module ElasticWhenever
       attr_reader :commands
       attr_reader :assign_public_ip
       attr_reader :launch_type
+      attr_reader :platform_version
       attr_reader :security_groups
       attr_reader :subnets
 
@@ -43,6 +44,7 @@ module ElasticWhenever
         @role = role
         @assign_public_ip = option.assign_public_ip
         @launch_type = option.launch_type
+        @platform_version = option.platform_version
         @security_groups = option.security_groups
         @subnets = option.subnets
         @client = Aws::CloudWatchEvents::Client.new(option.aws_config)
@@ -64,11 +66,12 @@ module ElasticWhenever
                   task_count: 1,
                   network_configuration: {
                     awsvpc_configuration: {
-                      subnets: [ subnets ],
-                      security_groups: [ security_groups ],
+                      subnets: subnets.split(','),
+                      security_groups: security_groups.split(','),
                       assign_public_ip: assign_public_ip,
                     }
-                  }
+                  },
+                  platform_version: platform_version
                 }
               }
             ]
@@ -83,6 +86,7 @@ module ElasticWhenever
                 input: input_json(container, commands),
                 role_arn: role.arn,
                 ecs_parameters: {
+                  launch_type: launch_type,
                   task_definition_arn: definition.arn,
                   task_count: 1,
                 }

--- a/lib/elastic_whenever/version.rb
+++ b/lib/elastic_whenever/version.rb
@@ -1,3 +1,3 @@
 module ElasticWhenever
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe ElasticWhenever::CLI do
   describe "run" do
     let(:task) do
-      ElasticWhenever::Task.new("production", "bundle exec", "cron(0 0 * * ? *)").tap do |task|
+      ElasticWhenever::Task.new("production", false, "bundle exec", "cron(0 0 * * ? *)").tap do |task|
         task.runner("Hoge.run")
       end
     end
@@ -21,7 +21,7 @@ RSpec.describe ElasticWhenever::CLI do
     let(:definition) { double(arn: "arn:aws:ecs:us-east-1:123456789:task-definition/wordpress:2", name: "wordpress:2", containers: ["testContainer"]) }
     let(:role) { double(arn: "arn:aws:ecs:us-east-1:123456789:role/testRole") }
     before do
-      allow(ElasticWhenever::Schedule).to receive(:new).with((Pathname(__dir__) + "fixtures/schedule.rb").to_s, kind_of(Array)).and_return(schedule)
+      allow(ElasticWhenever::Schedule).to receive(:new).with((Pathname(__dir__) + "fixtures/schedule.rb").to_s, boolean, kind_of(Array)).and_return(schedule)
       allow(ElasticWhenever::Task::Cluster).to receive(:new).with(kind_of(ElasticWhenever::Option), "test").and_return(cluster)
       allow(ElasticWhenever::Task::Definition).to receive(:new).with(kind_of(ElasticWhenever::Option), "wordpress:2").and_return(definition)
       allow(ElasticWhenever::Task::Role).to receive(:new).with(kind_of(ElasticWhenever::Option)).and_return(role)
@@ -77,7 +77,7 @@ RSpec.describe ElasticWhenever::CLI do
       end
 
       it "receives schedule file name and variables" do
-        expect(ElasticWhenever::Schedule).to receive(:new).with((Pathname(__dir__) + "fixtures/schedule.rb").to_s, [{ key: "environment", value: "staging" }, { key: "cluster", value: "ecs-test" }])
+        expect(ElasticWhenever::Schedule).to receive(:new).with((Pathname(__dir__) + "fixtures/schedule.rb").to_s, boolean, [{ key: "environment", value: "staging" }, { key: "cluster", value: "ecs-test" }])
 
         ElasticWhenever::CLI.run(%W(-i test --set environment=staging&cluster=ecs-test --region us-east-1 -f #{(Pathname(__dir__) + "fixtures/schedule.rb").to_s}))
       end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe ElasticWhenever::Schedule do
-  let(:schedule) { ElasticWhenever::Schedule.new((Pathname(__dir__) + "fixtures/schedule.rb").to_s, []) }
+  let(:schedule) { ElasticWhenever::Schedule.new((Pathname(__dir__) + "fixtures/schedule.rb").to_s, false, []) }
 
   describe "#initialize" do
     it "has attributes" do
@@ -14,7 +14,7 @@ RSpec.describe ElasticWhenever::Schedule do
     end
 
     context "when received variables from cli" do
-      let(:schedule) { ElasticWhenever::Schedule.new((Pathname(__dir__) + "fixtures/schedule.rb").to_s, [{ key: "environment", value: "staging" }]) }
+      let(:schedule) { ElasticWhenever::Schedule.new((Pathname(__dir__) + "fixtures/schedule.rb").to_s, false, [{ key: "environment", value: "staging" }]) }
 
       it "overrides attributes" do
         expect(schedule.instance_variable_get(:@environment)).to eq "staging"
@@ -39,7 +39,7 @@ RSpec.describe ElasticWhenever::Schedule do
     end
 
     context "when use unsupported method" do
-      let(:schedule) { ElasticWhenever::Schedule.new((Pathname(__dir__) + "fixtures/unsupported_schedule.rb").to_s, []) }
+      let(:schedule) { ElasticWhenever::Schedule.new((Pathname(__dir__) + "fixtures/unsupported_schedule.rb").to_s, false, []) }
 
       it "does not have tasks" do
         expect(schedule.tasks.count).to eq(0)

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe ElasticWhenever::Task do
-  let(:task) { ElasticWhenever::Task.new("production", "bundle exec", "cron(0 17 * * ? *)") }
+  let(:task) { ElasticWhenever::Task.new("production", false, "bundle exec", "cron(0 17 * * ? *)") }
 
   describe "#initialize" do
     it "has attributes" do
@@ -23,7 +23,7 @@ RSpec.describe ElasticWhenever::Task do
     end
 
     context "when unset bundle command" do
-      let(:task) { ElasticWhenever::Task.new("production", "", "cron(0 17 * * ? *)") }
+      let(:task) { ElasticWhenever::Task.new("production", false, "", "cron(0 17 * * ? *)") }
 
       it "generates rake commands" do
         task.rake("hoge:run")
@@ -39,7 +39,7 @@ RSpec.describe ElasticWhenever::Task do
     end
 
     context "when unset bundle command" do
-      let(:task) { ElasticWhenever::Task.new("production", "", "cron(0 17 * * ? *)") }
+      let(:task) { ElasticWhenever::Task.new("production", false, "", "cron(0 17 * * ? *)") }
 
       it "generates rake commands" do
         task.runner("Hoge.run")
@@ -55,7 +55,7 @@ RSpec.describe ElasticWhenever::Task do
     end
 
     context "when unset bundle command" do
-      let(:task) { ElasticWhenever::Task.new("production", "", "cron(0 17 * * ? *)") }
+      let(:task) { ElasticWhenever::Task.new("production", false, "", "cron(0 17 * * ? *)") }
 
       it "generates rake commands" do
         task.script("runner.rb")

--- a/spec/tasks/rule_spec.rb
+++ b/spec/tasks/rule_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
 
   describe "convert" do
     it "converts scheduled task syntax" do
-      task = ElasticWhenever::Task.new("production", "bundle exec", "cron(0 0 * * ? *)")
+      task = ElasticWhenever::Task.new("production", false, "bundle exec", "cron(0 0 * * ? *)")
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task)).to have_attributes(

--- a/spec/tasks/target_spec.rb
+++ b/spec/tasks/target_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe ElasticWhenever::Task::Target do
             }.to_json,
             role_arn: "arn:aws:ecs:us-east-1:123456789:role/testRole",
             ecs_parameters: {
+              launch_type: "EC2",
               task_definition_arn: "arn:aws:ecs:us-east-1:123456789:task-definition/wordpress:2",
               task_count: 1,
             }


### PR DESCRIPTION
Made a quick attempt to get this gem working with FARGATE launch type. example usage:

```
elastic_whenever --region us-west-2 --launch_type FARGATE --security_groups sg-2c503655,sg-72f0cb0a --subnets subnet-4973d63f,subnet-45827d1d --update <MY_SERVICE>
```

Happy to polish this up further if you have any suggestions.

See: https://aws.amazon.com/about-aws/whats-new/2018/08/aws-fargate-now-supports-time-and-event-based-task-scheduling/