### PR TITLE
Bump aws-sdk-cloudwatchevents dependency

### DIFF
--- a/elastic_whenever.gemspec
+++ b/elastic_whenever.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_dependency "aws-sdk-ecs", "~> 1.0"
-  spec.add_dependency "aws-sdk-cloudwatchevents", "~> 1.0"
+  spec.add_dependency "aws-sdk-cloudwatchevents", "~> 1.5"
   spec.add_dependency "aws-sdk-iam", "~> 1.0"
   spec.add_dependency "chronic", "~> 0.10"
 end


### PR DESCRIPTION
See https://github.com/aws/aws-sdk-ruby/commit/43687b4ce5c670ad5491cce52a99994d1cdbc9e0

Fargate launch type is supported only 1.5 or later.