### PR TITLE
Pass ECS params as an argument

### DIFF
--- a/lib/elastic_whenever/cli.rb
+++ b/lib/elastic_whenever/cli.rb
@@ -36,7 +36,6 @@ module ElasticWhenever
         ERROR_EXIT_CODE
       rescue OptionParser::MissingArgument,
         Option::InvalidOptionException,
-        Schedule::InvalidScheduleException,
         Task::Target::InvalidContainerException => exn
 
         Logger.instance.fail(exn.message)
@@ -47,10 +46,9 @@ module ElasticWhenever
 
       def update_tasks(option, dry_run:)
         schedule = Schedule.new(option.schedule_file, option.verbose, option.variables)
-        schedule.validate!
 
-        cluster = Task::Cluster.new(option, schedule.cluster)
-        definition = Task::Definition.new(option, schedule.task_definition)
+        cluster = Task::Cluster.new(option, option.cluster)
+        definition = Task::Definition.new(option, option.task_definition)
         role = Task::Role.new(option)
         if !role.exists? && !dry_run
           role.create
@@ -64,7 +62,7 @@ module ElasticWhenever
               option,
               cluster: cluster,
               definition: definition,
-              container: schedule.container,
+              container: option.container,
               commands: command,
               rule: rule,
               role: role,

--- a/lib/elastic_whenever/schedule.rb
+++ b/lib/elastic_whenever/schedule.rb
@@ -1,14 +1,10 @@
 module ElasticWhenever
   class Schedule
     attr_reader :tasks
-    attr_reader :cluster
-    attr_reader :task_definition
-    attr_reader :container
     attr_reader :chronic_options
     attr_reader :bundle_command
     attr_reader :environment
 
-    class InvalidScheduleException < StandardError; end
     class UnsupportedFrequencyException < StandardError; end
 
     module WheneverNumeric
@@ -55,9 +51,6 @@ module ElasticWhenever
       @environment = "production"
       @verbose = verbose
       @tasks = []
-      @cluster = nil
-      @task_definition = nil
-      @container = nil
       @chronic_options = {}
       @bundle_command = "bundle exec"
 
@@ -75,12 +68,6 @@ module ElasticWhenever
       end
     rescue UnsupportedFrequencyException => exn
       Logger.instance.warn(exn.message)
-    end
-
-    def validate!
-      raise InvalidScheduleException.new("You must set cluster") unless cluster
-      raise InvalidScheduleException.new("You must set task definition") unless task_definition
-      raise InvalidScheduleException.new("You must set container") unless container
     end
 
     def schedule_expression(frequency, options)

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -5,12 +5,7 @@ RSpec.describe ElasticWhenever::Schedule do
 
   describe "#initialize" do
     it "has attributes" do
-      expect(schedule).to have_attributes(
-                            cluster: "ecs-test",
-                            task_definition: "example",
-                            container: "cron",
-                            chronic_options: {},
-                          )
+      expect(schedule).to have_attributes(chronic_options: {})
     end
 
     context "when received variables from cli" do
@@ -266,44 +261,14 @@ RSpec.describe ElasticWhenever::Schedule do
   describe "#set" do
     it "sets value" do
       expect {
-        schedule.set("container", "original")
-      }.to change { schedule.container }.from("cron").to("original")
+        schedule.set("foo", "bar")
+      }.to change { schedule.instance_variable_get("@foo") }.from(nil).to("bar")
     end
 
     it "doesnt set `tasks` value" do
       expect {
         schedule.set("tasks", "some value")
       }.not_to change { schedule.tasks }
-    end
-  end
-
-  describe "#validate!" do
-    it "doesnt raise exception" do
-      schedule.validate!
-    end
-
-    context "when doesnt set cluster" do
-      before { schedule.set("cluster", nil) }
-
-      it "raises exception" do
-        expect { schedule.validate! }.to raise_error(ElasticWhenever::Schedule::InvalidScheduleException, "You must set cluster")
-      end
-    end
-
-    context "when doesnt set task definition" do
-      before { schedule.set("task_definition", nil) }
-
-      it "raises exception" do
-        expect { schedule.validate! }.to raise_error(ElasticWhenever::Schedule::InvalidScheduleException, "You must set task definition")
-      end
-    end
-
-    context "when doesnt set container" do
-      before { schedule.set("container", nil) }
-
-      it "raises exception" do
-        expect { schedule.validate! }.to raise_error(ElasticWhenever::Schedule::InvalidScheduleException, "You must set container")
-      end
     end
   end
 


### PR DESCRIPTION
Previously, basic ECS params are passed from variables in a schedule file. This was worthwhile making it possible to write all configurations in the schedule file. However, this approach is not good in order to pass complicated options like Fargate.

In this pull request, schedule file focus on Whenever's features, and ECS params are passed from arguments. This is a breaking change, but it is important for consistency of design.