### PR TITLE
Retry for concurrent modification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ rvm:
   - 2.6.3
 before_install:
   - gem update --system
+  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 before_install:
   - gem update --system

--- a/elastic_whenever.gemspec
+++ b/elastic_whenever.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-cloudwatchevents", "~> 1.5"
   spec.add_dependency "aws-sdk-iam", "~> 1.0"
   spec.add_dependency "chronic", "~> 0.10"
+  spec.add_dependency "retryable", "~> 3.0"
 end

--- a/elastic_whenever.gemspec
+++ b/elastic_whenever.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 

--- a/lib/elastic_whenever.rb
+++ b/lib/elastic_whenever.rb
@@ -5,6 +5,7 @@ require "aws-sdk-iam"
 require "chronic"
 require "singleton"
 require "json"
+require "retryable"
 
 require "elastic_whenever/version"
 require "elastic_whenever/cli"


### PR DESCRIPTION
When CloudWatch events are modified at the same time, sometimes the following exception is raised:

```
$ elastic_whenever --cluster example --task-definition example_oneoff --container oneoff --set environment=production -i example 
/root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.59.0/lib/seahorse/client/plugins/raise_response_errors.rb:15:in `call': Aws::CloudWatchEvents::Errors::ConcurrentModificationException 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.59.0/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call' 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.59.0/lib/aws-sdk-core/plugins/idempotency_token.rb:17:in `call' 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.59.0/lib/aws-sdk-core/plugins/param_converter.rb:24:in `call' 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.59.0/lib/aws-sdk-core/plugins/response_paging.rb:10:in `call' 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.59.0/lib/seahorse/client/plugins/response_target.rb:23:in `call' 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/aws-sdk-core-3.59.0/lib/seahorse/client/request.rb:70:in `send_request' 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/aws-sdk-cloudwatchevents-1.23.0/lib/aws-sdk-cloudwatchevents/client.rb:1513:in `put_rule' 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/elastic_whenever-0.4.0/lib/elastic_whenever/task/rule.rb:35:in `create' 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/elastic_whenever-0.4.0/lib/elastic_whenever/cli.rb:76:in `block in update_tasks' 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/elastic_whenever-0.4.0/lib/elastic_whenever/cli.rb:58:in `each' 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/elastic_whenever-0.4.0/lib/elastic_whenever/cli.rb:58:in `update_tasks' 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/elastic_whenever-0.4.0/lib/elastic_whenever/cli.rb:17:in `run' 
    from /root/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/elastic_whenever-0.4.0/exe/elastic_whenever:5:in `<top (required)>' 
    from /root/.rbenv/versions/2.6.3/bin/elastic_whenever:23:in `load' 
    from /root/.rbenv/versions/2.6.3/bin/elastic_whenever:23:in `<main>' 
```

We may be able to avoid the error by sleeping at random and retrying the process from scratch. This PR adds implementation such as retrying.