### PR TITLE
Add expression to task rule name hash computation

### DIFF
--- a/lib/elastic_whenever/task/rule.rb
+++ b/lib/elastic_whenever/task/rule.rb
@@ -20,7 +20,7 @@ module ElasticWhenever
       def self.convert(option, task)
         self.new(
           option,
-          name: rule_name(option.identifier, task.commands),
+          name: rule_name(option.identifier, task.expression, task.commands),
           expression: task.expression
         )
       end
@@ -47,8 +47,8 @@ module ElasticWhenever
 
       private
 
-      def self.rule_name(identifier, commands)
-        "#{identifier}_#{Digest::SHA1.hexdigest(commands.map { |command| command.join("-") }.join("-"))}"
+      def self.rule_name(identifier, expression, commands)
+        "#{identifier}_#{Digest::SHA1.hexdigest([expression, commands.map { |command| command.join("-") }.join("-")].join("-"))}"
       end
 
       attr_reader :client

--- a/spec/tasks/rule_spec.rb
+++ b/spec/tasks/rule_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
       task.rake "hoge:run"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task)).to have_attributes(
-                                                                     name: "test_b7ae861e5b0deb3dde12c9a65a179fad6ad36018",
+                                                                     name: "test_9bd25c94ceb04edcaa64946e7ed84f13644d655f",
                                                                      expression: "cron(0 0 * * ? *)"
                                                                    )
     end


### PR DESCRIPTION
This PR fixes an issue we ran into when using `elastic_whenever`: multiple rule blocks with the same commands and different timing expressions would not get created, since the rule name hashes collide.

(We've got a lot of tasks we need to run on multiple schedules.)