### PR TITLE
Make CloudWatch Events IAM role name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Usage: elastic_whenever [options]
         --subnets subnets            Example: --subnets 'subnet-4973d63f,subnet-45827d1d' (FARGATE only)
         --platform-version version   Optionally specify the platform version. Default: LATEST (FARGATE only)
     -f, --file schedule_file         Default: config/schedule.rb
+        --iam-role name              IAM role name used by CloudWatch Events. Default: ecsEventsRole
         --profile profile_name       AWS shared profile name
         --access-key aws_access_key_id
                                      AWS access key ID

--- a/lib/elastic_whenever/option.rb
+++ b/lib/elastic_whenever/option.rb
@@ -19,6 +19,7 @@ module ElasticWhenever
     attr_reader :security_groups
     attr_reader :subnets
     attr_reader :schedule_file
+    attr_reader :iam_role
 
     class InvalidOptionException < StandardError; end
 
@@ -36,6 +37,7 @@ module ElasticWhenever
       @security_groups = []
       @subnets = []
       @schedule_file = 'config/schedule.rb'
+      @iam_role = 'ecsEventsRole'
       @profile = nil
       @access_key = nil
       @secret_key = nil
@@ -91,6 +93,9 @@ module ElasticWhenever
         end
         opts.on('-f', '--file schedule_file', 'Default: config/schedule.rb') do |file|
           @schedule_file = file
+        end
+        opts.on('--iam-role name', 'IAM role name used by CloudWatch Events. Default: ecsEventsRole') do |role|
+          @iam_role = role
         end
         opts.on('--profile profile_name', 'AWS shared profile name') do |profile|
           @profile = profile

--- a/lib/elastic_whenever/task/role.rb
+++ b/lib/elastic_whenever/task/role.rb
@@ -1,17 +1,16 @@
 module ElasticWhenever
   class Task
     class Role
-      NAME = "ecsEventsRole"
-
       def initialize(option)
         client = Aws::IAM::Client.new(option.aws_config)
         @resource = Aws::IAM::Resource.new(client: client)
-        @role = resource.role(NAME)
+        @role_name = option.iam_role
+        @role = resource.role(@role_name)
       end
 
       def create
         @role = resource.create_role(
-          role_name: NAME,
+          role_name: @role_name,
           assume_role_policy_document: role_json,
         )
         role.attach_policy(

--- a/spec/option_spec.rb
+++ b/spec/option_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe ElasticWhenever::Option do
                                                     variables: [],
                                                     subnets: [],
                                                     security_groups: [],
-                                                    schedule_file: "config/schedule.rb"
+                                                    schedule_file: "config/schedule.rb",
+                                                    iam_role: "ecsEventsRole",
                                                   )
     end
 
@@ -45,7 +46,8 @@ RSpec.describe ElasticWhenever::Option do
         ],
         subnets: ["subnet-4973d63f", "subnet-45827d1d"],
         security_groups: ["sg-2c503655", "sg-72f0cb0a"],
-        schedule_file: "custom_schedule.rb"
+        schedule_file: "custom_schedule.rb",
+        iam_role: "ecsEventsRole",
       )
     end
 

--- a/spec/tasks/role_spec.rb
+++ b/spec/tasks/role_spec.rb
@@ -3,23 +3,33 @@ require "spec_helper"
 RSpec.describe ElasticWhenever::Task::Role do
   let(:resource) { double("resource") }
   let(:option) { ElasticWhenever::Option.new(%w(--region us-east-1)) }
-  let(:role) { double(arn: "arn:aws:iam::123456789:role/ecsEventsRole") }
+  let(:role_name) { "ecsEventsRole" }
+  let(:role) { double(arn: "arn:aws:iam::123456789:role/#{role_name}") }
 
   before do
     allow(Aws::IAM::Resource).to receive(:new).and_return(resource)
-    allow(resource).to receive(:role).with(ElasticWhenever::Task::Role::NAME).and_return(role)
+    allow(resource).to receive(:role).with(role_name).and_return(role)
   end
 
   describe "#initialize" do
     it "has role" do
       expect(ElasticWhenever::Task::Role.new(option)).to have_attributes(arn: "arn:aws:iam::123456789:role/ecsEventsRole")
     end
+
+    context "with custom role name" do
+      let(:role_name) { "cloudwatch-events-ecs" }
+      let(:option) { ElasticWhenever::Option.new(%w(--region us-east-1 --iam-role cloudwatch-events-ecs)) }
+
+      it "has role" do
+        expect(ElasticWhenever::Task::Role.new(option)).to have_attributes(arn: "arn:aws:iam::123456789:role/cloudwatch-events-ecs")
+      end
+    end
   end
 
   describe "#create" do
     it "creates IAM role" do
       expect(resource).to receive(:create_role).with({
-                                                       role_name: ElasticWhenever::Task::Role::NAME,
+                                                       role_name: role_name,
                                                        assume_role_policy_document: {
                                                          Version: "2012-10-17",
                                                          Statement: [


### PR DESCRIPTION
This allows the IAM role used for CloudWatch Events rules to be changed
from the default, also making it easier to define the role elsewhere
(e.g. Terraform, CloudFormation) and have elastic_whenever use a
named existing one.