### PR TITLE
Add description to CloudWatch rule

### DIFF
--- a/lib/elastic_whenever/task/rule.rb
+++ b/lib/elastic_whenever/task/rule.rb
@@ -28,7 +28,7 @@ module ElasticWhenever
         )
       end
 
-      def initialize(option, name:, expression:, description: "")
+      def initialize(option, name:, expression:, description:)
         @name = name
         @expression = expression
         @description = description

--- a/lib/elastic_whenever/task/rule.rb
+++ b/lib/elastic_whenever/task/rule.rb
@@ -3,6 +3,7 @@ module ElasticWhenever
     class Rule
       attr_reader :name
       attr_reader :expression
+      attr_reader :description
 
       class UnsupportedOptionException < StandardError; end
 
@@ -13,6 +14,7 @@ module ElasticWhenever
             option,
             name: rule.name,
             expression: rule.schedule_expression,
+            description: rule.description
           )
         end
       end
@@ -21,13 +23,15 @@ module ElasticWhenever
         self.new(
           option,
           name: rule_name(option.identifier, task.expression, task.commands),
-          expression: task.expression
+          expression: task.expression,
+          description: rule_description(option.identifier, task.expression, task.commands)
         )
       end
 
-      def initialize(option, name:, expression:)
+      def initialize(option, name:, expression:, description: "")
         @name = name
         @expression = expression
+        @description = description
         @client = Aws::CloudWatchEvents::Client.new(option.aws_config)
       end
 
@@ -35,6 +39,7 @@ module ElasticWhenever
         client.put_rule(
           name: name,
           schedule_expression: expression,
+          description: description,
           state: "ENABLED",
         )
       end
@@ -49,6 +54,10 @@ module ElasticWhenever
 
       def self.rule_name(identifier, expression, commands)
         "#{identifier}_#{Digest::SHA1.hexdigest([expression, commands.map { |command| command.join("-") }.join("-")].join("-"))}"
+      end
+
+      def self.rule_description(identifier, expression, commands)
+        "#{identifier} - #{expression} - #{commands.map { |command| command.join(" ") }.join(" - ")}"
       end
 
       attr_reader :client

--- a/lib/elastic_whenever/task/rule.rb
+++ b/lib/elastic_whenever/task/rule.rb
@@ -39,7 +39,8 @@ module ElasticWhenever
         client.put_rule(
           name: name,
           schedule_expression: expression,
-          description: description,
+          # See https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutRule.html#API_PutRule_RequestSyntax
+          description: truncate(description, 512),
           state: "ENABLED",
         )
       end
@@ -58,6 +59,10 @@ module ElasticWhenever
 
       def self.rule_description(identifier, expression, commands)
         "#{identifier} - #{expression} - #{commands.map { |command| command.join(" ") }.join(" - ")}"
+      end
+
+      def truncate(string, max)
+        string.length > max ? string[0...max] : string
       end
 
       attr_reader :client

--- a/spec/tasks/rule_spec.rb
+++ b/spec/tasks/rule_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe ElasticWhenever::Task::Rule do
       expect(client).to receive(:put_rule).with(name: "example", schedule_expression: "cron(0 0 * * ? *)", description: "test", state: "ENABLED")
       ElasticWhenever::Task::Rule.new(option, name: "example", expression: "cron(0 0 * * ? *)", description: "test").create
     end
+
+    it "truncates the description at 512 characters" do
+      expect(client).to receive(:put_rule).with(name: "example", schedule_expression: "cron(0 0 * * ? *)", description: "a" * 512, state: "ENABLED")
+      ElasticWhenever::Task::Rule.new(option, name: "example", expression: "cron(0 0 * * ? *)", description: "a" * 600).create
+    end
   end
 
   describe "#delete" do

--- a/spec/tasks/rule_spec.rb
+++ b/spec/tasks/rule_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
     it "remove rule and targets" do
       expect(client).to receive(:remove_targets).with(rule: "example", ids: ["example_id"])
       expect(client).to receive(:delete_rule).with(name: "example")
-      ElasticWhenever::Task::Rule.new(option, name: "example", expression: "cron(0 0 * * ? *)").delete
+      ElasticWhenever::Task::Rule.new(option, name: "example", expression: "cron(0 0 * * ? *)", description: "test").delete
     end
   end
 end

--- a/spec/tasks/rule_spec.rb
+++ b/spec/tasks/rule_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ElasticWhenever::Task::Rule do
 
   describe "fetch" do
     before do
-      allow(client).to receive(:list_rules).with(name_prefix: "test").and_return(double(rules: [double(name: "example", schedule_expression: "cron(0 0 * * ? *)")]))
+      allow(client).to receive(:list_rules).with(name_prefix: "test").and_return(double(rules: [double(name: "example", schedule_expression: "cron(0 0 * * ? *)", description: "test")]))
     end
 
     it "fetches rule" do
@@ -21,18 +21,20 @@ RSpec.describe ElasticWhenever::Task::Rule do
     it "converts scheduled task syntax" do
       task = ElasticWhenever::Task.new("production", false, "bundle exec", "cron(0 0 * * ? *)")
       task.rake "hoge:run"
+      task.rake "command:foo"
 
       expect(ElasticWhenever::Task::Rule.convert(option, task)).to have_attributes(
-                                                                     name: "test_9bd25c94ceb04edcaa64946e7ed84f13644d655f",
-                                                                     expression: "cron(0 0 * * ? *)"
+                                                                     name: "test_a46a593729246bb4947ee259c46edf2a9a55d8f2",
+                                                                     expression: "cron(0 0 * * ? *)",
+                                                                     description: "test - cron(0 0 * * ? *) - bundle exec rake hoge:run --silent - bundle exec rake command:foo --silent"
                                                                    )
     end
   end
 
   describe "#create" do
     it "creates new rule" do
-      expect(client).to receive(:put_rule).with(name: "example", schedule_expression: "cron(0 0 * * ? *)", state: "ENABLED")
-      ElasticWhenever::Task::Rule.new(option, name: "example", expression: "cron(0 0 * * ? *)").create
+      expect(client).to receive(:put_rule).with(name: "example", schedule_expression: "cron(0 0 * * ? *)", description: "test", state: "ENABLED")
+      ElasticWhenever::Task::Rule.new(option, name: "example", expression: "cron(0 0 * * ? *)", description: "test").create
     end
   end
 


### PR DESCRIPTION
Hey,

I had a usecase where I was trying to get the CW Rule metrics from the command. This should add a bit more information to the description field to make searching in the console a bit easier.