### PR TITLE
Add option to disable rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Usage: elastic_whenever [options]
         --platform-version version   Optionally specify the platform version. Default: LATEST (FARGATE only)
     -f, --file schedule_file         Default: config/schedule.rb
         --iam-role name              IAM role name used by CloudWatch Events. Default: ecsEventsRole
+        --rule-state state           The state of the CloudWatch Events Rule (ENABLED or DISABLED), default: ENABLED
         --profile profile_name       AWS shared profile name
         --access-key aws_access_key_id
                                      AWS access key ID

--- a/lib/elastic_whenever/option.rb
+++ b/lib/elastic_whenever/option.rb
@@ -1,5 +1,7 @@
 module ElasticWhenever
   class Option
+    POSSIBLE_RULE_STATES = %w[ENABLED DISABLED].freeze
+
     DRYRUN_MODE = 1
     UPDATE_MODE = 2
     CLEAR_MODE = 3
@@ -20,6 +22,7 @@ module ElasticWhenever
     attr_reader :subnets
     attr_reader :schedule_file
     attr_reader :iam_role
+    attr_reader :rule_state
 
     class InvalidOptionException < StandardError; end
 
@@ -38,6 +41,7 @@ module ElasticWhenever
       @subnets = []
       @schedule_file = 'config/schedule.rb'
       @iam_role = 'ecsEventsRole'
+      @rule_state = 'ENABLED'
       @profile = nil
       @access_key = nil
       @secret_key = nil
@@ -97,6 +101,9 @@ module ElasticWhenever
         opts.on('--iam-role name', 'IAM role name used by CloudWatch Events. Default: ecsEventsRole') do |role|
           @iam_role = role
         end
+        opts.on('--rule-state state', 'The state of the CloudWatch Events Rule. Default: ENABLED') do |state|
+          @rule_state = state
+        end
         opts.on('--profile profile_name', 'AWS shared profile name') do |profile|
           @profile = profile
         end
@@ -133,6 +140,7 @@ module ElasticWhenever
       raise InvalidOptionException.new("You must set cluster") unless cluster
       raise InvalidOptionException.new("You must set task definition") unless task_definition
       raise InvalidOptionException.new("You must set container") unless container
+      raise InvalidOptionException.new("Invalid rule state. Possible values are #{POSSIBLE_RULE_STATES.join(", ")}") unless POSSIBLE_RULE_STATES.include?(rule_state)
     end
 
     private

--- a/lib/elastic_whenever/task/rule.rb
+++ b/lib/elastic_whenever/task/rule.rb
@@ -1,6 +1,7 @@
 module ElasticWhenever
   class Task
     class Rule
+      attr_reader :option
       attr_reader :name
       attr_reader :expression
       attr_reader :description
@@ -29,6 +30,7 @@ module ElasticWhenever
       end
 
       def initialize(option, name:, expression:, description:)
+        @option = option
         @name = name
         @expression = expression
         @description = description
@@ -36,12 +38,12 @@ module ElasticWhenever
       end
 
       def create
+        # See https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutRule.html#API_PutRule_RequestSyntax
         client.put_rule(
           name: name,
           schedule_expression: expression,
-          # See https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutRule.html#API_PutRule_RequestSyntax
           description: truncate(description, 512),
-          state: "ENABLED",
+          state: option.rule_state,
         )
       end
 

--- a/spec/option_spec.rb
+++ b/spec/option_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe ElasticWhenever::Option do
                                                     security_groups: [],
                                                     schedule_file: "config/schedule.rb",
                                                     iam_role: "ecsEventsRole",
+                                                    rule_state: "ENABLED"
                                                   )
     end
 
@@ -32,6 +33,7 @@ RSpec.describe ElasticWhenever::Option do
           --subnets subnet-4973d63f,subnet-45827d1d
           --platform-version 1.1.0
           --verbose
+          --rule_state DISABLED
         ))
       ).to have_attributes(
         identifier: nil,
@@ -48,6 +50,7 @@ RSpec.describe ElasticWhenever::Option do
         security_groups: ["sg-2c503655", "sg-72f0cb0a"],
         schedule_file: "custom_schedule.rb",
         iam_role: "ecsEventsRole",
+        rule_state: "DISABLED"
       )
     end
 
@@ -154,6 +157,18 @@ RSpec.describe ElasticWhenever::Option do
           --task-definition wordpress:2
         )).validate! 
       }.to raise_error(ElasticWhenever::Option::InvalidOptionException, "You must set container")
+    end
+
+    it "raises an exception if the rule state is invalid" do
+      expect {
+        ElasticWhenever::Option.new(%W(
+          -f #{Pathname(__dir__) + "fixtures/schedule.rb"}
+          --cluster test
+          --task-definition wordpress:2
+          --container testContainer
+          --rule-state FOO
+        )).validate!
+      }.to raise_error(ElasticWhenever::Option::InvalidOptionException, "Invalid rule state. Possible values are ENABLED, DISABLED")
     end
 
     it "doesn't raise exception" do

--- a/spec/tasks/rule_spec.rb
+++ b/spec/tasks/rule_spec.rb
@@ -41,6 +41,15 @@ RSpec.describe ElasticWhenever::Task::Rule do
       expect(client).to receive(:put_rule).with(name: "example", schedule_expression: "cron(0 0 * * ? *)", description: "a" * 512, state: "ENABLED")
       ElasticWhenever::Task::Rule.new(option, name: "example", expression: "cron(0 0 * * ? *)", description: "a" * 600).create
     end
+
+    context "with custom rule state" do
+      let(:option) { ElasticWhenever::Option.new(%w(-i test --rule-state DISABLED)) }
+
+      it "uses the rule state when creating the rule" do
+        expect(client).to receive(:put_rule).with(name: "example", schedule_expression: "cron(0 0 * * ? *)", description: "test", state: "DISABLED")
+        ElasticWhenever::Task::Rule.new(option, name: "example", expression: "cron(0 0 * * ? *)", description: "test").create
+      end
+    end
   end
 
   describe "#delete" do


### PR DESCRIPTION
This PR adds an option to deploy the tasks but with the options disabled. We have a use case where we would like to migrate from whenever to elastic_whenever but want to avoid multiple executions from multiple environments.

Please let me know what you think.