### PR TITLE
Bump rake development dependency

### DIFF
--- a/elastic_whenever.gemspec
+++ b/elastic_whenever.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_dependency "aws-sdk-ecs", "~> 1.0"


### PR DESCRIPTION
Bump rake dependencies to avoid Ruby 2.7 warnings.