### PR TITLE
Fix API limit issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.6.1 (2020-11-06)
+
+### BugFixes
+
+- [#51](https://github.com/wata727/elastic_whenever/pull/51): Avoid hitting rate limits fetching credentials when running under ECS or with an IAM profile  ([@stevenwilliamson](https://github.com/stevenwilliamson))
+
 ## v0.6.0 (2019-10-16)
 
 ### Enhancements

--- a/lib/elastic_whenever/task/rule.rb
+++ b/lib/elastic_whenever/task/rule.rb
@@ -9,7 +9,7 @@ module ElasticWhenever
       class UnsupportedOptionException < StandardError; end
 
       def self.fetch(option)
-        client = Aws::CloudWatchEvents::Client.new(options.aws_config)
+        client = Aws::CloudWatchEvents::Client.new(option.aws_config)
         client.list_rules(name_prefix: option.identifier).rules.map do |rule|
           self.new(
             option,

--- a/lib/elastic_whenever/task/rule.rb
+++ b/lib/elastic_whenever/task/rule.rb
@@ -36,7 +36,6 @@ module ElasticWhenever
         @expression = expression
         @description = description
         if client != nil
-          puts("using cached client")
           @client = client
         else
           @client = Aws::CloudWatchEvents::Client.new(option.aws_config)

--- a/lib/elastic_whenever/version.rb
+++ b/lib/elastic_whenever/version.rb
@@ -1,3 +1,3 @@
 module ElasticWhenever
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
When fetching all tasks ensure that the existing AWS Client is passed to the new task object and re-used this prevents a lookup for credentials for every task. Otherwise if you have lots of tasks and you run inside ECS  as task for example you will hit the rate limit asking for new credentials as each new client that is created makes a new call.

This rate limit on ECS appears to be a burst of 60 and steady rate of 40 per second.

This PR fixes the issue by passing in the already created AWS client to the new task objects created as part of the fetch operation.