### PR TITLE
Safe update

### DIFF
--- a/exe/elastic_whenever
+++ b/exe/elastic_whenever
@@ -2,4 +2,4 @@
 
 require "elastic_whenever"
 
-exit ElasticWhenever::CLI.run(ARGV)
+exit ElasticWhenever::CLI.new(ARGV).run

--- a/lib/elastic_whenever/cli.rb
+++ b/lib/elastic_whenever/cli.rb
@@ -3,123 +3,149 @@ module ElasticWhenever
     SUCCESS_EXIT_CODE = 0
     ERROR_EXIT_CODE = 1
 
-    class << self
-      def run(args)
-        option = Option.new(args)
-        case option.mode
-        when Option::DRYRUN_MODE
-          option.validate!
-          update_tasks(option, dry_run: true)
-          Logger.instance.message("Above is your schedule file converted to scheduled tasks; your scheduled tasks was not updated.")
-          Logger.instance.message("Run `elastic_whenever --help' for more options.")
-        when Option::UPDATE_MODE
-          option.validate!
-          with_concurrent_modification_handling do
-            update_tasks(option, dry_run: false)
-          end
-          Logger.instance.log("write", "scheduled tasks updated")
-        when Option::CLEAR_MODE
-          with_concurrent_modification_handling do
-            clear_tasks(option)
-          end
-          Logger.instance.log("write", "scheduled tasks cleared")
-        when Option::LIST_MODE
-          list_tasks(option)
-          Logger.instance.message("Above is your scheduled tasks.")
-          Logger.instance.message("Run `elastic_whenever --help` for more options.")
-        when Option::PRINT_VERSION_MODE
-          print_version
+    attr_reader :args, :option
+
+    def initialize(args)
+      @args = args
+      @option = Option.new(args)
+    end
+
+    def run
+      case option.mode
+      when Option::DRYRUN_MODE
+        option.validate!
+        update_tasks(dry_run: true)
+        Logger.instance.message("Above is your schedule file converted to scheduled tasks; your scheduled tasks was not updated.")
+        Logger.instance.message("Run `elastic_whenever --help' for more options.")
+      when Option::UPDATE_MODE
+        option.validate!
+        with_concurrent_modification_handling do
+          update_tasks(dry_run: false)
         end
-
-        SUCCESS_EXIT_CODE
-      rescue Aws::Errors::MissingRegionError
-        Logger.instance.fail("missing region error occurred; please use `--region` option or export `AWS_REGION` environment variable.")
-        ERROR_EXIT_CODE
-      rescue Aws::Errors::MissingCredentialsError
-        Logger.instance.fail("missing credential error occurred; please specify it with arguments, use shared credentials, or export `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variable.")
-        ERROR_EXIT_CODE
-      rescue OptionParser::MissingArgument,
-        Option::InvalidOptionException,
-        Task::Target::InvalidContainerException => exn
-
-        Logger.instance.fail(exn.message)
-        ERROR_EXIT_CODE
+        Logger.instance.log("write", "scheduled tasks updated")
+      when Option::CLEAR_MODE
+        with_concurrent_modification_handling do
+          clear_tasks
+        end
+        Logger.instance.log("write", "scheduled tasks cleared")
+      when Option::LIST_MODE
+        list_tasks
+        Logger.instance.message("Above is your scheduled tasks.")
+        Logger.instance.message("Run `elastic_whenever --help` for more options.")
+      when Option::PRINT_VERSION_MODE
+        print_version
       end
 
-      private
+      SUCCESS_EXIT_CODE
+    rescue Aws::Errors::MissingRegionError
+      Logger.instance.fail("missing region error occurred; please use `--region` option or export `AWS_REGION` environment variable.")
+      ERROR_EXIT_CODE
+    rescue Aws::Errors::MissingCredentialsError => e
+      Logger.instance.fail("missing credential error occurred; please specify it with arguments, use shared credentials, or export `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variable. #{e.backtrace}")
+      ERROR_EXIT_CODE
+    rescue OptionParser::MissingArgument,
+      Option::InvalidOptionException,
+      Task::Target::InvalidContainerException => exn
 
-      def update_tasks(option, dry_run:)
-        schedule = Schedule.new(option.schedule_file, option.verbose, option.variables)
+      Logger.instance.fail(exn.message)
+      ERROR_EXIT_CODE
+    end
 
-        cluster = Task::Cluster.new(option, option.cluster)
-        definition = Task::Definition.new(option, option.task_definition)
-        role = Task::Role.new(option)
-        if !role.exists? && !dry_run
-          role.create
-        end
+    private
 
-        clear_tasks(option) unless dry_run
-        schedule.tasks.each do |task|
-          rule = Task::Rule.convert(option, task)
-          targets = task.commands.map do |command|
-            Task::Target.new(
-              option,
-              cluster: cluster,
-              definition: definition,
-              container: option.container,
-              commands: command,
-              rule: rule,
-              role: role,
-            )
-          end
+    def update_tasks(dry_run:)
+      schedule = Schedule.new(option.schedule_file, option.verbose, option.variables)
 
-          if dry_run
-            print_task(rule, targets)
-          else
-            begin
-              rule.create
-            rescue Aws::CloudWatchEvents::Errors::ValidationException => exn
-              Logger.instance.warn("#{exn.message} Ignore this task: name=#{rule.name} expression=#{rule.expression}")
-              next
-            end
-            targets.each(&:create)
-          end
-        end
+      cluster = Task::Cluster.new(option, option.cluster)
+      definition = Task::Definition.new(option, option.task_definition)
+      role = Task::Role.new(option)
+      if !role.exists? && !dry_run
+        role.create
       end
 
-      def clear_tasks(option)
-        Task::Rule.fetch(option).each(&:delete)
-      end
+      targets = schedule.tasks.map do |task|
+        task.commands.map do |command|
+          Task::Target.new(
+            option,
+            cluster: cluster,
+            definition: definition,
+            container: option.container,
+            commands: command,
+            rule: Task::Rule.convert(option, task.expression, command),
+            role: role,
+          )
+        end
+      end.flatten
 
-      def list_tasks(option)
-        Task::Rule.fetch(option).each do |rule|
-          targets = Task::Target.fetch(option, rule)
-          print_task(rule, targets)
+      if dry_run
+        print_task(targets)
+      else
+        create_missing_rules_from_targets(targets)
+        delete_unused_rules_from_targets(targets)
+      end
+    end
+
+    def remote_rules
+      Task::Rule.fetch(option)
+    end
+
+    # Creates a rule but only persists the rule remotely if it does not exist
+    def create_missing_rules_from_targets(targets)
+      cached_remote_rules = remote_rules
+      targets.each do |target|
+        exists = cached_remote_rules.any? do |remote_rule|
+          target.rule.name == remote_rule.name
+        end
+
+        unless exists
+          target.rule.create
+          target.create
         end
       end
+    end
 
-      def print_version
-        puts "Elastic Whenever v#{ElasticWhenever::VERSION}"
-      end
-
-      def print_task(rule, targets)
-        targets.each do |target|
-          puts "#{rule.expression} #{target.cluster.name} #{target.definition.name} #{target.container} #{target.commands.join(" ")}"
-          puts
+    def delete_unused_rules_from_targets(targets)
+      remote_rules.each do |remote_rule|
+        rule_exists_in_schedule = targets.any? do |target|
+          target.rule.name == remote_rule.name
         end
-      end
 
-      def with_concurrent_modification_handling
-        Retryable.retryable(
-          tries: 5,
-          on: Aws::CloudWatchEvents::Errors::ConcurrentModificationException,
-          sleep: lambda { |_n| rand(1..10) },
-        ) do |retries, exn|
-          if retries > 0
-            Logger.instance.warn("concurrent modification detected; Retrying...")
-          end
-          yield
+        remote_rule.delete unless rule_exists_in_schedule
+      end
+    end
+
+    def clear_tasks
+      Task::Rule.fetch(option).each(&:delete)
+    end
+
+    def list_tasks
+      Task::Rule.fetch(option).each do |rule|
+        targets = Task::Target.fetch(option, rule)
+        print_task(targets)
+      end
+    end
+
+    def print_version
+      puts "Elastic Whenever v#{ElasticWhenever::VERSION}"
+    end
+
+    def print_task(targets)
+      targets.each do |target|
+        puts "#{target.rule.expression} #{target.cluster.name} #{target.definition.name} #{target.container} #{target.commands.join(" ")}"
+        puts
+      end
+    end
+
+    def with_concurrent_modification_handling
+      Retryable.retryable(
+        tries: 5,
+        on: Aws::CloudWatchEvents::Errors::ConcurrentModificationException,
+        sleep: lambda { |_n| rand(1..10) },
+      ) do |retries, exn|
+        if retries > 0
+          Logger.instance.warn("concurrent modification detected; Retrying...")
         end
+        yield
       end
     end
   end

--- a/lib/elastic_whenever/option.rb
+++ b/lib/elastic_whenever/option.rb
@@ -23,6 +23,10 @@ module ElasticWhenever
     attr_reader :schedule_file
     attr_reader :iam_role
     attr_reader :rule_state
+    attr_reader :aws_config
+    attr_reader :ecs_client
+    attr_reader :iam_client
+    attr_reader :cloudwatch_events_client
 
     class InvalidOptionException < StandardError; end
 
@@ -48,7 +52,7 @@ module ElasticWhenever
       @region = nil
 
       OptionParser.new do |opts|
-        opts.on('-i', '--update identifier', 'Clear and create scheduled tasks by schedule file') do |identifier|
+        opts.on('-i', '--update identifier', 'Creates and deletes tasks as needed by schedule file') do |identifier|
           @identifier = identifier
           @mode = UPDATE_MODE
         end
@@ -132,7 +136,19 @@ module ElasticWhenever
     end
 
     def aws_config
-      { credentials: credentials, region: region }.delete_if { |_k, v| v.nil? }
+      @aws_config ||= { credentials: credentials, region: region }.delete_if { |_k, v| v.nil? }
+    end
+
+    def ecs_client
+      @ecs_client ||= Aws::ECS::Client.new(aws_config)
+    end
+
+    def iam_client
+      @iam_client ||= Aws::IAM::Client.new(aws_config)
+    end
+
+    def cloudwatch_events_client
+      @cloudwatch_events_client ||= Aws::CloudWatchEvents::Client.new(aws_config)
     end
 
     def validate!

--- a/lib/elastic_whenever/task/cluster.rb
+++ b/lib/elastic_whenever/task/cluster.rb
@@ -4,7 +4,7 @@ module ElasticWhenever
       class InvalidInputException < StandardError; end
 
       def initialize(option, name)
-        @client = Aws::ECS::Client.new(option.aws_config)
+        @client = option.ecs_client
         @cluster = client.describe_clusters(
           clusters: [name]
         ).clusters.first

--- a/lib/elastic_whenever/task/definition.rb
+++ b/lib/elastic_whenever/task/definition.rb
@@ -2,7 +2,7 @@ module ElasticWhenever
   class Task
     class Definition
       def initialize(option, family)
-        @client = Aws::ECS::Client.new(option.aws_config)
+        @client = option.ecs_client
         @definition = client.describe_task_definition(
           task_definition: family
         ).task_definition

--- a/lib/elastic_whenever/task/role.rb
+++ b/lib/elastic_whenever/task/role.rb
@@ -2,7 +2,7 @@ module ElasticWhenever
   class Task
     class Role
       def initialize(option)
-        client = Aws::IAM::Client.new(option.aws_config)
+        client = option.iam_client
         @resource = Aws::IAM::Resource.new(client: client)
         @role_name = option.iam_role
         @role = resource.role(@role_name)

--- a/lib/elastic_whenever/task/target.rb
+++ b/lib/elastic_whenever/task/target.rb
@@ -10,11 +10,13 @@ module ElasticWhenever
       attr_reader :platform_version
       attr_reader :security_groups
       attr_reader :subnets
+      attr_reader :rule
 
       class InvalidContainerException < StandardError; end
 
       def self.fetch(option, rule)
-        client = Aws::CloudWatchEvents::Client.new(option.aws_config)
+        client = option.cloudwatch_events_client
+        Logger.instance.message("Fetching Targets for: #{rule.name}")
         targets = client.list_targets_by_rule(rule: rule.name).targets
         targets.map do |target|
           input = JSON.parse(target.input, symbolize_names: true)
@@ -26,7 +28,7 @@ module ElasticWhenever
             container: input[:containerOverrides].first[:name],
             commands: input[:containerOverrides].first[:command],
             rule: rule,
-            role: Role.new(option)
+            role: Role.new(option),
           )
         end
       end
@@ -47,10 +49,11 @@ module ElasticWhenever
         @platform_version = option.platform_version
         @security_groups = option.security_groups
         @subnets = option.subnets
-        @client = Aws::CloudWatchEvents::Client.new(option.aws_config)
+        @client = option.cloudwatch_events_client
       end
 
       def create
+        Logger.instance.message("Creating Target: #{rule.name}")
         client.put_targets(
           rule: rule.name,
           targets: [
@@ -102,7 +105,6 @@ module ElasticWhenever
         end
       end
 
-      attr_reader :rule
       attr_reader :role
       attr_reader :client
     end

--- a/spec/tasks/rule_spec.rb
+++ b/spec/tasks/rule_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe ElasticWhenever::Task::Rule do
       task.rake "hoge:run"
       task.rake "command:foo"
 
-      expect(ElasticWhenever::Task::Rule.convert(option, task)).to have_attributes(
-                                                                     name: "test_a46a593729246bb4947ee259c46edf2a9a55d8f2",
+      expect(ElasticWhenever::Task::Rule.convert(option, task.expression, task.commands.first)).to have_attributes(
+                                                                     name: "test_9bd25c94ceb04edcaa64946e7ed84f13644d655f",
                                                                      expression: "cron(0 0 * * ? *)",
-                                                                     description: "test - cron(0 0 * * ? *) - bundle exec rake hoge:run --silent - bundle exec rake command:foo --silent"
+                                                                     description: "test - cron(0 0 * * ? *) - bundle exec rake hoge:run --silent"
                                                                    )
     end
   end

--- a/spec/tasks/target_spec.rb
+++ b/spec/tasks/target_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ElasticWhenever::Task::Target do
             ]
           }.to_json,
           arn: "arn:aws:ecs:us-east-1:123456789:cluster/test",
-          ecs_parameters: double(task_definition_arn: "arn:aws:ecs:us-east-1:123456789:task-definition/wordpress:2")
+          ecs_parameters: double(task_definition_arn: "arn:aws:ecs:us-east-1:123456789:task-definition/wordpress:2"),
         )
       ]
     end


### PR DESCRIPTION
Hello 👋

We've been using elastic-whenever for a little while to configure our scheduled tasks on ECS. In most cases it's been working very well (so thank you for your great work).  However, recently we began using it on an application which is deployed much more frequently and this interfered with our scheduled tasks. We think this is down to a timing issue and that the update method deletes and re-creates all targets/rules on update.

The following PR changes the functionality of the update method to:
* Only create rules and targets which have been altered
* Only delete any unused targets and rules
* Log more on interactions with AWS SDKs.

To implement this we have changed the Rule and Target relationship, so a rule only has a single target. This allows us to only updated Rules and Targets if/when they have been updated with the least impact on other rules and targets.  The caveat to this is AWS has a soft limit of 300 rules.

While adding this we have slightly modified the CLI class, to allow instantiating it.  We have also provided aws client methods on the options, to cache them at the Option level. This means we instantiate less AWS SDK Clients, which results in fewer calls to the underlying ec2-metadata when using a role on ECS/EC2.

We wanted to raise this PR early, to get your opinion on the changes and to see if you have any objections to our approach? We will continue to test this functionality throughout next week. If you have any thoughts or feedback we would be thankful.

Thank you for your help