### PR TITLE
CI against Ruby 3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: ['2.5.x', '2.6.x', '2.7.x']
+        ruby_version: ['2.6', '2.7', '3.0']
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby ${{ matrix.ruby_version }}
-      uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
-    - name: Run spec
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        bundle exec rake
+        bundler-cache: true
+    - run: bundle exec rake


### PR DESCRIPTION
And this PR migrates setup action to `ruby/setup-ruby` from `actions/setup-ruby` because the action will be deprecated. See https://github.com/actions/setup-ruby/issues/80