### PR TITLE
Add the rexml dependency explictly

### DIFF
--- a/elastic_whenever.gemspec
+++ b/elastic_whenever.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-iam", "~> 1.0"
   spec.add_dependency "chronic", "~> 0.10"
   spec.add_dependency "retryable", "~> 3.0"
+  spec.add_dependency "rexml", ">= 0"
 end


### PR DESCRIPTION
See also https://github.com/aws/aws-sdk-ruby/pull/2459#discussion_r552967179

Ruby 3.0 build is failing because rexml is now bundled gem and aws-sdk-ruby requires to add XML parser dependency explicitly.

https://github.com/wata727/elastic_whenever/runs/1712170050

```
An error occurred while loading ./spec/schedule_spec.rb.
Failure/Error: require "aws-sdk-ecs"

RuntimeError:
  Unable to find a compatible xml library. Ensure that you have installed or added to your Gemfile one of ox, oga, libxml, nokogiri or rexml
# ./vendor/bundle/ruby/3.0.0/gems/aws-sdk-core-3.111.1/lib/aws-sdk-core/xml/parser.rb:74:in `set_default_engine'
```