### PR TITLE
CI against Ruby 3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: ['2.7', '3.0', '3.1']
+        ruby_version: ['3.0', '3.1', '3.2']
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/