### PR TITLE
Remove unnecessary rexml dependency from gemspec

### DIFF
--- a/elastic_whenever.gemspec
+++ b/elastic_whenever.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-iam", "~> 1.0"
   spec.add_dependency "chronic", "~> 0.10"
   spec.add_dependency "retryable", "~> 3.0"
-  spec.add_dependency "rexml", ">= 0"
 end


### PR DESCRIPTION
Remove unnecessary rexml dependency from gemspec as it's in ruby's standard gems since 3.0, e.g. https://ruby-doc.org/3.0.6/gems/rexml/REXML.html

We're trying to limit adding unnecessary gem dependencies and since you don't have ruby < 3 any more in your build matrix, I'd suggest to remove it from the dependencies again.