### PR TITLE
Fix week converion issue in cron syntax.

### DIFF
--- a/lib/elastic_whenever/schedule.rb
+++ b/lib/elastic_whenever/schedule.rb
@@ -136,7 +136,7 @@ module ElasticWhenever
         day.gsub!("*", "?") if week != "?"
         # cron syntax:          sunday -> 0
         # scheduled expression: sunday -> 1
-        week.gsub!(/(\d)/) { (Integer($1) + 1) % 7 }
+        week.gsub!(/(\d)/) { Integer($1) + 1 }
         year = year || "*"
         "cron(#{min} #{hour} #{day} #{mon} #{week} #{year})"
       # schedule expression syntax

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe ElasticWhenever::Schedule do
     end
 
     it "converts from cron syntax specified week" do
-      expect(schedule.schedule_expression("0 0 * * 0", {})).to eq "cron(0 0 ? * 1 *)"
+      expect(schedule.schedule_expression("0 0 * * 0,1,2,3,4,5,6", {})).to eq "cron(0 0 ? * 1,2,3,4,5,6,7 *)"
     end
 
     it "converts from day shortcuts" do


### PR DESCRIPTION
Hello
 
I got a error when using cron syntax. In the day of week conversion, an exception occurs when it becomes divisible by and turns into 0.

ex). (6+1) % 7 = 0 

## Error occurred
`Aws::CloudWatchEvents::Errors::ValidationException: Parameter ScheduleExpression is not valid`

## Used schedule expression

```
 every '30 1,8 * * 0,1,4,5,6' do
    runner 'Example.execute'
 end
```

## Output
`cron(30 1,8 ? * 1,2,5,6,0 *)`

